### PR TITLE
Add repo and meetings pages (not currently linked)

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,6 +15,7 @@ We based in the Nordic area, but inclusive to others.
 ## Goals
 
 Share solutions and problems across centers and across countries.
+Collaborative maintenance of said solutions.
 
 Improve the usability of HPC and large research computing systems for
 the modern world.

--- a/meetings.md
+++ b/meetings.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: NordicHPC meetings
+---
+
+# NordicHPC meetings
+
+## About
+
+NordicHPC meetings are a time for staff of Nordic computing centers to
+meet up and exchange best practices and tips.
+
+## Next meeting
+
+2-day meeting (lunch-lunch), probably Stockholm or Helsinki area,
+probably autumn 2019 or spring 2020. Please contact
+radovan.bast@uit.no if you would like to be informed about such
+events.
+
+## Schedule
+
+The general idea is:
+- Most of half-day 1: each attendee presents 5-10 cool things that happen
+  at their site, and 5-10 common problems they have.  This allows us
+  to network and look for problem-solution pairs.
+- Most of half-day 2: collaborative working together in an
+  unconference-type format.
+- Discussion of collaboration models.

--- a/meetings.md
+++ b/meetings.md
@@ -8,7 +8,8 @@ title: NordicHPC meetings
 ## About
 
 NordicHPC meetings are a time for staff of Nordic computing centers to
-meet up and exchange best practices and tips.  Computing centers tend
+meet up and exchange best practices and tips, and work on joint
+software that helps everyone.  Computing centers tend
 to be quite independent and conservative, but we all have the same
 problems.  Why not work on solutions together?
 
@@ -26,5 +27,5 @@ The general idea is:
   at their site, and 5-10 common problems they have.  This allows us
   to network and look for problem-solution pairs.
 - Most of half-day 2: collaborative working together in an
-  unconference-type format.
+  unconference-type format, based on lessons of the first half.
 - Discussion of collaboration models.

--- a/meetings.md
+++ b/meetings.md
@@ -8,7 +8,9 @@ title: NordicHPC meetings
 ## About
 
 NordicHPC meetings are a time for staff of Nordic computing centers to
-meet up and exchange best practices and tips.
+meet up and exchange best practices and tips.  Computing centers tend
+to be quite independent and conservative, but we all have the same
+problems.  Why not work on solutions together?
 
 ## Next meeting
 

--- a/repo.md
+++ b/repo.md
@@ -1,0 +1,65 @@
+---
+layout: default
+title: NordicHPC Github repository
+---
+
+# NordicHPC Github repository
+
+NordicHPC has a [Github organization](https://github.com/NordicHPC/)
+which is used for co-maintains of useful code and other material.  We
+don't yet entirely know how this works yet, but this is our general
+idea.
+
+In theory, there is no benefit to hosting code here rather than on an
+institutional page.  Still, there are some benefits: We'd always
+recommend NordicHPC over using a personal Github account, because it
+provides a way for code to be inherited and maintained over a longer
+period of time (yes, we realize that personal Github accounts are like
+a CV now, it's unfortunate that this is at conflict with group
+maintenance).  There is less benefit of NordicHPC compared to other
+institutional Github organizations, but this provides better
+visibility, more eyes, and more users.
+
+
+
+## General principles
+
+- Scripts should be open source sufficiently so that others can use.
+
+- We presume that each code will have some primary maintainers.
+  However, we recognize that people come and go, so recommend that we
+  wait a short time for the main maintainers to accept a pull request,
+  then some time for others with knowledge to accept a pull request,
+  and then anyone else is assumed to be welcome to accept pull
+  requests.  Those that accept a PR should be aware enough to see
+  follow-up and help with any problems that may come up afterwards!
+
+- The README should indicate any particular notes related to
+  maintenance.
+
+- Things maintained here don't have to be perfect, well maintained, or
+  ready for general use.  Just document the general maturity level,
+  and of course if there's not much documentation it will be assumed
+  that it's not very mature.  Try to include at least a basic README.
+
+
+
+## Who?
+
+We are called "**Nordic** HPC" but we realize we shouldn't exclude
+others.  Still, we have started as a local community.  We will at
+least add as members anyone working at an academic computing center
+who chooses to be a part of NordicHPC.
+
+Come to our meetings to help decide how our membership will work.
+
+
+
+## Suggestions for readme files
+
+Readme files should list:
+
+- Site which has done primary development, key maintainers (not just
+  to help management, it's important to give credit when it is due).
+
+- Any requests on other members accepting pull requests.

--- a/repo.md
+++ b/repo.md
@@ -18,20 +18,20 @@ period of time (yes, we realize that personal Github accounts are like
 a CV now, it's unfortunate that this is at conflict with group
 maintenance).  There is less benefit of NordicHPC compared to other
 institutional Github organizations, but this provides better
-visibility, more eyes, and more users.
+visibility, more eyes, and more maintainers and users.
 
 
 
 ## General principles
 
-- Scripts should be open source sufficiently so that others can use.
+- Repositories should be open source sufficiently so that others can use.
 
 - We presume that each code will have some primary maintainers.
   However, we recognize that people come and go, so recommend that we
   wait a short time for the main maintainers to accept a pull request,
   then some time for others with knowledge to accept a pull request,
   and then anyone else is assumed to be welcome to accept pull
-  requests.  Those that accept a PR should be aware enough to see
+  requests.  Those that accept a PR should be aware enough to track
   follow-up and help with any problems that may come up afterwards!
 
 - The README should indicate any particular notes related to
@@ -42,16 +42,18 @@ visibility, more eyes, and more users.
   and of course if there's not much documentation it will be assumed
   that it's not very mature.  Try to include at least a basic README.
 
+- As projects get larger, open source community best practices should
+  be followed more and more... in proportion to what is useful.
 
 
 ## Who?
 
 We are called "**Nordic** HPC" but we realize we shouldn't exclude
 others.  Still, we have started as a local community.  We will at
-least add as members anyone working at an academic computing center
+least add as members anyone working at a Nordic academic computing center
 who chooses to be a part of NordicHPC.
 
-Come to our meetings to help decide how our membership will work.
+Come to our meetings to help decide how this works in practice.
 
 
 


### PR DESCRIPTION
Initial attempt at a repo.md and meetings.md pages.

repo.md contains my initial attempt at description of using the shared hosting - some is opinions and needs discussion.

meetings.md contains basic meeting idea.

Neither are linked or integrated with the main page yet.