### PR TITLE
Helsinki meeting: Add lightning talks and requested sessions section

### DIFF
--- a/2019-11-14-helsinki.md
+++ b/2019-11-14-helsinki.md
@@ -96,6 +96,19 @@ system](https://github.com/AaltoScienceIT/science-build-rules) which
 automates Spack, Singularity, and more across multiple systems.
 Organizer: Simo Tuomisto
 
+**Lightning talks**: Anyone who wants to give a lightning talk, let us
+know.  There's no topic too small, especially consider talks on small
+problems, solutions, or UI problems you have.
+
+### Requested sessions
+
+If anyone would like to present on these topics, let us know.  You
+don't have to be an expert, you can also facilitate the discussion.
+
+**Managing I/O for machine learning**: How to best help users who make
+millions of small files with a wide variety of machine learning
+frameworks.
+
 
 ## Resources / Sharing
 

--- a/2019-11-14-helsinki.md
+++ b/2019-11-14-helsinki.md
@@ -57,24 +57,30 @@ break-out sessions or parallel tracks.
   * Early arrivals?  Come find us in room A243 or the obvious coffee
     room in the A2 corridor.
   * 11:00 Lunch for those who have arrived
-  * 12:00 Afternoon session in room T4
-    * Site presentations: Three cool things and three problems
-    * Nordic Jupyter
+  * 12:00 Afternoon session
+    * Talks
+	* Breakout sessions, either planned or to continue discussions
+      inspired by talks
   * Evening: group dinner
 * 15 November
-  * 09:00 Meeting continues in room T4
-    * Software
-    * More (suggest topics)
-    * Discussing next steps
+  * 09:00 Meeting continues
+    * Talks
+    * Discussing future the NordicHPC collaboration
+	* Breakout sessions
   * Program ends at 12:00, room reserved until 14:00
 
-**Suggestions**: Suggest your own, either in advance or during
-the meeting, by adding to [the agenda google
+**Contribute!**: Request a talk or suggest your own, either in advance
+or during the meeting, by adding to [the agenda google
 doc](https://docs.google.com/document/d/1l5BCK7EWEQ-eNpUbcoPC64SfCoCCJIJ6bTJ7Hn0mGwE).
-Slides and material can also be uploaded there.
+You can also directly contribute by [making a Github issue or PR](https://github.com/NordicHPC/nordichpc.github.io/labels/meetings).
+Slides and material can also be uploaded to the Google Drive.
+The exact program will be adjusted based on attendee interest closer
+to time.
 
 
 ### Session descriptions
+
+The following sessions have been offered so far:
 
 **Cool things and problems**: Each site presents around three cool
 things that their site does, and three problems they have.  This
@@ -100,10 +106,12 @@ Organizer: Simo Tuomisto
 know.  There's no topic too small, especially consider talks on small
 problems, solutions, or UI problems you have.
 
+
 ### Requested sessions
 
 If anyone would like to present on these topics, let us know.  You
 don't have to be an expert, you can also facilitate the discussion.
+You can also add to the google doc linked above and below.
 
 **Managing I/O for machine learning**: How to best help users who make
 millions of small files with a wide variety of machine learning


### PR DESCRIPTION
Despite the branch name, this adds lightning talks and a requested
sessions section, since they are right next to each other and would
conflict.