### PR TITLE
Link NeIC workshop material from meetings page

### DIFF
--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@ and issues with the hope of improving the user experience but also the
 
 Next: [Helsinki, November 14-15](/2019-11-14-helsinki/).
 
-In general: [meetings](/meetings/)
+In general, including past events: [meetings](/meetings/)
 
 2-day meetings (lunch-lunch) in an easy to access city, once or twice
 a year.  Please contact radovan.bast@uit.no if you would like to be

--- a/meetings.md
+++ b/meetings.md
@@ -33,3 +33,13 @@ Our standard general plan is:
   unconference-type format, based on lessons of the first half.
 - Break-out sessions can be reserved in advance.
 - Discussion of collaboration models.
+
+
+
+## Past meetings and events
+
+* [Reimagining Research Computing](/2019-05-15-neic/) workshop at the
+  Nordic e-Infrastructure Collaboration conference, 2019-05-15.  This
+  was the founding moment of NordicHPC.
+* Jupyter workshop at the same NeIC conference.  Materials are
+  available on the [Jupyter page](/jupyter/)


### PR DESCRIPTION
- The Reimagining research computing workshop stuff was there, just
  not linked from anywhere.
- Is the meetings page the best place to link them?