### PR TITLE
Helsinki meeting: adjust "ideal attendee" section

### DIFF
--- a/2019-11-14-helsinki.md
+++ b/2019-11-14-helsinki.md
@@ -33,8 +33,9 @@ doers.
 You can [register here](https://forms.gle/u9VLEcoWcSbWkgpk9)
 for attendance, possible attendance, or remote attendance.
 
-The ideal attendee is working in supporting general-purpose computing
-infrastructure in the Nordics, but other users or interested parties
+The ideal attendee is working in developing, maintaining, or supporting
+general-purpose computing infrastructure in the Nordics, and has an
+ability to take ideas into practice on their systems.  Other users or interested parties
 are welcome as well.  We'll try to make room for anyone in academic
 computing centers in the Nordics.
 


### PR DESCRIPTION
- We want to make sure that people who can actually *get stuff done*
  at our sites attend, too - sysadmins and the like.  This is implied
  but perhaps we could emphasize it a bit more.  This is my attempt to
  do that - please comment if this can still be improved.